### PR TITLE
fix: build not running before publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,10 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
+
+      - name: Build
+        run: npm run build
+
       - run: npm whoami; npm --ignore-scripts publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/test/job.test.ts
+++ b/test/job.test.ts
@@ -126,7 +126,7 @@ describe('Job', () => {
 			const job2 = new Job(agenda, { name: 'demo', type: 'normal' });
 			const now = new Date().valueOf();
 			job2.repeatEvery('3 minutes', { skipImmediate: true });
-			expect(job2.attrs.nextRunAt).to.be.within(new Date(now + 180000), new Date(now + 180002)); // Inclusive
+			expect(job2.attrs.nextRunAt).to.be.within(new Date(now + 180000 - 2), new Date(now + 180002)); // Inclusive
 		});
 		it('repeats from the existing nextRunAt property with skipImmediate', () => {
 			const job2 = new Job(agenda, { name: 'demo', type: 'normal' });


### PR DESCRIPTION
This PR fixes the publish workflow because the build was not running (because we're using `--ignore-scripts`).