### PR TITLE
fix: ensure type declarations are in build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,14 @@
 		"strict": true,
 		"noImplicitAny": false,
 		"removeComments": false,
+		"emitDecoratorMetadata": true,
+		"composite": true,
+		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
+		"resolveJsonModule": true,
 		"sourceMap": true,
+		"isolatedModules": false,
+		"declaration": true
 	},
 	"exclude": ["node_modules", "**/__tests__"],
 	"include": ["./src"]


### PR DESCRIPTION
This PR ensures the type declarations end up in the `/dist` folder. We accidentally turned them off.